### PR TITLE
Correct issue 8

### DIFF
--- a/testim-created/table-functions/table-cell-click.js
+++ b/testim-created/table-functions/table-cell-click.js
@@ -172,7 +172,7 @@ function tableRowFind(theGrid, rowSelector, matchType) {
             if (columnheader_row !== null)
                 columnheader_nodes = columnheader_row.querySelectorAll('th');
 
-            rows = theGrid.getElementsByTagName("tr");
+            rows = theGrid.querySelectorAll("tbody tr");
 
             break;
 


### PR DESCRIPTION
This change corrects issue #8.

The nature of the fix is such that any existing reference using the Table - Cell Click code and specifying an integer index where the target table has a header row (which would have caused the result to be off-by-1) will now be off-by-1 in the opposite direction.

The code is documented claiming the integer index is zero-based, it was in effect not zero-based when the table has a header row because the table header row took up the zero position.