### PR TITLE
Update element-value-validate.js

### DIFF
--- a/testim-created/element/element-value-validate.js
+++ b/testim-created/element/element-value-validate.js
@@ -91,7 +91,7 @@ if (['exact', 'startswith', 'endswith', 'includes', 'contains', 'notexact', 'not
         actualValue = element?.value;
     copyToClipboard(actualValue);
 
-    if (typeof expectedValue !== 'undefined' && expectedValue === null) {
+    if (typeof expectedValue !== 'undefined' && expectedValue !== null) {
         if (expression.startsWith("not")) {
             result = !stringMatch[expression.replace("not", "")](actualValue, expectedValue);
         }


### PR DESCRIPTION
'exact', 'startswith', 'endswith', 'includes', 'contains', 'notexact', 'notstartswith', 'notendswith', 'notincludes', 'notcontains' were not working because of line 94. 

Should be !== null instead of ===null